### PR TITLE
Add the reset stragegy for checking out objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@
 //! Example:
 //!
 //! ```
-//! use pool::Pool;
+//! use pool::{Pool, Dirty};
 //! use std::thread;
 //!
-//! let mut pool = Pool::with_capacity(20, 0, || Vec::with_capacity(16_384));
+//! let mut pool = Pool::with_capacity(20, 0, || Dirty(Vec::with_capacity(16_384)));
 //!
-//! let mut vec = pool.checkout_raw().unwrap();
+//! let mut vec = pool.checkout().unwrap();
 //!
 //! // Do some work with the value, this can happen in another thread
 //! thread::scoped(move || {
@@ -25,7 +25,7 @@
 //! });
 //!
 //! // The vec will have been returned to the pool by now
-//! let vec = pool.checkout_raw().unwrap();
+//! let vec = pool.checkout().unwrap();
 //!
 //! // The pool operates LIFO, so this vec will be the same value that was used
 //! // in the thread above. The value will also be left as it was when it was
@@ -54,16 +54,16 @@
 use std::{mem, ops, ptr, usize};
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
-pub use reset::Reset;
+pub use reset::{Reset, Dirty};
 
 mod reset;
 
 /// A pool of reusable values
-pub struct Pool<T> {
+pub struct Pool<T: Reset> {
     inner: Arc<PoolInner<T>>,
 }
 
-impl<T> Pool<T> {
+impl<T: Reset> Pool<T> {
     /// Creates a new pool that can contain up to `capacity` entries as well as
     /// `extra` extra bytes. Initializes each entry with the given function.
     pub fn with_capacity<F>(count: usize, mut extra: usize, init: F) -> Pool<T>
@@ -91,34 +91,21 @@ impl<T> Pool<T> {
     ///
     /// The value returned from the pool has not been reset and contains the
     /// state that it previously had when it was last released.
-    pub fn checkout_raw(&mut self) -> Option<Checkout<T>> {
+    pub fn checkout(&mut self) -> Option<Checkout<T>> {
         self.inner_mut().checkout()
             .map(|ptr| {
                 Checkout {
                     entry: ptr,
                     pool: self.inner.clone(),
                 }
+            }).map(|mut checkout| {
+                checkout.reset();
+                checkout
             })
     }
 
     fn inner_mut(&self) -> &mut PoolInner<T> {
         unsafe { mem::transmute(&*self.inner) }
-    }
-}
-
-impl <T: Reset> Pool<T> {
-    /// Checkout a value from the pool.  Returns `None` if the pool is currently
-    /// at capacity.
-    ///
-    /// The value returned has been reset to its empty state.
-    pub fn checkout(&mut self) -> Option<Checkout<T>> {
-        match self.checkout_raw() {
-            Some(mut obj) => {
-                obj.reset();
-                Some(obj)
-            }
-            None => None
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 use std::{mem, ops, ptr, usize};
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
-pub use reset::{Reset, Dirty};
+pub use reset::{Reset, Dirty, Default};
 
 mod reset;
 

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -1,47 +1,40 @@
-use std::collections::*;
+use std::default::Default;
+use std::ops::{Deref, DerefMut};
 
-/// Resetting an object that acts like a collection clears the contents of
-/// that collection and makes it so that collection behaves like it was not
-/// used before.
+#[derive(Debug)]
+pub struct Dirty<T>(pub T);
+
+impl <T> Reset for Dirty<T> {
+    fn reset(&mut self) {
+        // Do nothing!
+    }
+}
+
+unsafe impl <T: Send> Send for Dirty<T> {}
+unsafe impl <T: Sync> Sync for Dirty<T> {}
+
+impl <T> Deref for Dirty<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl <T> DerefMut for Dirty<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+/// Resetting an object reverts that object back to a default state.
 pub trait Reset {
     fn reset(&mut self);
 }
 
-impl <T> Reset for Vec<T> {
+// For most of the stdlib collections, this will "clear" the collection
+// without deallocating.
+impl <T: Default + Clone> Reset for T {
     fn reset(&mut self) {
-        self.clear();
+        self.clone_from(&Default::default());
     }
 }
-
-impl <T: Ord> Reset for BinaryHeap<T> {
-    fn reset(&mut self) {
-        self.clear();
-    }
-}
-
-impl <T> Reset for LinkedList<T> {
-    fn reset(&mut self) {
-        self.clear();
-    }
-}
-
-impl <T> Reset for VecDeque<T> {
-    fn reset(&mut self) {
-        self.clear();
-    }
-}
-
-impl Reset for String {
-    fn reset(&mut self) {
-        self.clear();
-    }
-}
-
-// TODO: uncomment when VecMap becomes stable
-/*
-impl <T> Reset for VecMap<T> {
-    fn reset(&mut self) {
-        self.clear();
-    }
-}
-*/

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -1,12 +1,21 @@
-use std::default::Default;
+use std::default::Default as StdDefault;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug)]
 pub struct Dirty<T>(pub T);
 
+#[derive(Debug)]
+pub struct Default<T: StdDefault + Clone>(pub T);
+
 impl <T> Reset for Dirty<T> {
     fn reset(&mut self) {
         // Do nothing!
+    }
+}
+
+impl <T: StdDefault + Clone> Reset for Default<T> {
+    fn reset(&mut self) {
+        self.0.clone_from(&StdDefault::default());
     }
 }
 
@@ -26,15 +35,23 @@ impl <T> DerefMut for Dirty<T> {
     }
 }
 
+unsafe impl <T: Send + Clone + StdDefault> Send for Default<T> {}
+unsafe impl <T: Sync + Clone + StdDefault> Sync for Default<T> {}
+
+impl <T: StdDefault + Clone> Deref for Default<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl <T: StdDefault + Clone> DerefMut for Default<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 /// Resetting an object reverts that object back to a default state.
 pub trait Reset {
     fn reset(&mut self);
-}
-
-// For most of the stdlib collections, this will "clear" the collection
-// without deallocating.
-impl <T: Default + Clone> Reset for T {
-    fn reset(&mut self) {
-        self.clone_from(&Default::default());
-    }
 }

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -1,0 +1,47 @@
+use std::collections::*;
+
+/// Resetting an object that acts like a collection clears the contents of
+/// that collection and makes it so that collection behaves like it was not
+/// used before.
+pub trait Reset {
+    fn reset(&mut self);
+}
+
+impl <T> Reset for Vec<T> {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+
+impl <T: Ord> Reset for BinaryHeap<T> {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+
+impl <T> Reset for LinkedList<T> {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+
+impl <T> Reset for VecDeque<T> {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+
+impl Reset for String {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+
+// TODO: uncomment when VecMap becomes stable
+/*
+impl <T> Reset for VecMap<T> {
+    fn reset(&mut self) {
+        self.clear();
+    }
+}
+*/

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,20 +1,20 @@
 extern crate pool;
 
-use pool::Pool;
+use pool::{Pool, Dirty};
 
 #[test]
 pub fn test_checkout_checkin() {
-    let mut pool: Pool<i32> = Pool::with_capacity(10, 0, || 0);
+    let mut pool: Pool<Dirty<i32>> = Pool::with_capacity(10, 0, || Dirty(0));
 
-    let mut val = pool.checkout_raw().unwrap();
-    assert_eq!(*val, 0);
+    let mut val = pool.checkout().unwrap();
+    assert_eq!(**val, 0);
 
     // Update the value & return to the pool
-    *val = 1;
+    *val = Dirty(1);
     drop(val);
 
-    let val = pool.checkout_raw().unwrap();
-    assert_eq!(*val, 1);
+    let val = pool.checkout().unwrap();
+    assert_eq!(**val, 1);
 }
 
 #[test]
@@ -25,7 +25,7 @@ pub fn test_multiple_checkouts() {
     let mut vec = vec![];
 
     for _ in 0..10 {
-        let mut i = pool.checkout_raw().unwrap();
+        let mut i = pool.checkout().unwrap();
         assert_eq!(*i, 0);
         *i = 1;
         vec.push(i);
@@ -39,12 +39,12 @@ pub fn test_depleting_pool() {
     let mut vec = vec![];
 
     for _ in 0..5 {
-        vec.push(pool.checkout_raw().unwrap());
+        vec.push(pool.checkout().unwrap());
     }
 
-    assert!(pool.checkout_raw().is_none());
+    assert!(pool.checkout().is_none());
     drop(vec);
-    assert!(pool.checkout_raw().is_some());
+    assert!(pool.checkout().is_some());
 }
 
 #[test]

--- a/test/test.rs
+++ b/test/test.rs
@@ -6,14 +6,14 @@ use pool::Pool;
 pub fn test_checkout_checkin() {
     let mut pool: Pool<i32> = Pool::with_capacity(10, 0, || 0);
 
-    let mut val = pool.checkout().unwrap();
+    let mut val = pool.checkout_raw().unwrap();
     assert_eq!(*val, 0);
 
     // Update the value & return to the pool
     *val = 1;
     drop(val);
 
-    let val = pool.checkout().unwrap();
+    let val = pool.checkout_raw().unwrap();
     assert_eq!(*val, 1);
 }
 
@@ -25,7 +25,7 @@ pub fn test_multiple_checkouts() {
     let mut vec = vec![];
 
     for _ in 0..10 {
-        let mut i = pool.checkout().unwrap();
+        let mut i = pool.checkout_raw().unwrap();
         assert_eq!(*i, 0);
         *i = 1;
         vec.push(i);
@@ -39,12 +39,26 @@ pub fn test_depleting_pool() {
     let mut vec = vec![];
 
     for _ in 0..5 {
-        vec.push(pool.checkout().unwrap());
+        vec.push(pool.checkout_raw().unwrap());
     }
 
-    assert!(pool.checkout().is_none());
+    assert!(pool.checkout_raw().is_none());
     drop(vec);
-    assert!(pool.checkout().is_some());
+    assert!(pool.checkout_raw().is_some());
+}
+
+#[test]
+pub fn test_resetting_pool() {
+    let mut pool: Pool<Vec<i32>> = Pool::with_capacity(1, 0, || Vec::new());
+    {
+        let mut val = pool.checkout().unwrap();
+        val.push(5);
+        val.push(6);
+    }
+    {
+        let val = pool.checkout().unwrap();
+        assert!(val.len() == 0);
+    }
 }
 
 // TODO: Add concurrency stress tests


### PR DESCRIPTION
This pull request changes the name of the `checkout` function to `checkout_raw` and adds a new function named `checkout` for objects that can be "reset" back to a neutral state.
