### PR TITLE
Prevent blatent unsafety with extra_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name          = "pool"
-version       = "0.1.2"
+version       = "0.1.3"
 license       = "MIT"
 authors       = ["Carl Lerche <me@carllerche.com>"]
 description   = "A pool of reusable values"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use `pool`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pool = "0.1.1"
+pool = "0.1.3"
 ```
 
 Then, add this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl<T> Checkout<T> {
     }
 
     /// Write access to the extra bytes
-    pub fn extra_mut(&self) -> &mut [u8] {
+    pub fn extra_mut(&mut self) -> &mut [u8] {
         self.entry_mut().extra_mut()
     }
 
@@ -137,7 +137,7 @@ impl<T> Checkout<T> {
         unsafe { mem::transmute(self.entry) }
     }
 
-    fn entry_mut(&self) -> &mut Entry<T> {
+    fn entry_mut(&mut self) -> &mut Entry<T> {
         unsafe { mem::transmute(self.entry) }
     }
 
@@ -298,6 +298,7 @@ impl<T> PoolInner<T> {
         }
     }
 
+    #[allow(mutable_transmutes)]
     fn entry_mut(&mut self, idx: usize) -> &mut Entry<T> {
         unsafe { mem::transmute(self.entry(idx)) }
     }
@@ -331,6 +332,7 @@ impl<T> Entry<T> {
         }
     }
 
+    #[allow(mutable_transmutes)]
     fn extra_mut(&mut self) -> &mut [u8] {
         unsafe { mem::transmute(self.extra()) }
     }


### PR DESCRIPTION
This API allowed to _easily_ alias multiple `&mut [u8]`, which wreaks havoc on
alias analysis and causes llvm-level UB.
