### PR TITLE
Fix breakage for RFC 1214

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<T: Reset> Pool<T> {
     }
 }
 
-unsafe impl<T: Send> Send for Pool<T> { }
+unsafe impl<T: Send + Reset> Send for Pool<T> { }
 
 /// A handle to a checked out value. When dropped out of scope, the value will
 /// be returned to the pool.


### PR DESCRIPTION
Hi!

This PR contains fixes for breakage due to [RFC 1214](https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md). These changes
will hit stable Rust in version 1.7, released on March 3. This patch
should be compatible with both 1.7 and 1.6. Your crate was identified
as being broken by the upcoming release in a recent crater [regression
test](https://internals.rust-lang.org/t/regression-report-stable-2016-01-21-vs-beta-2016-02-04/3171). For more details about how we're responding to this breakage
see [this previous announcement](https://users.rust-lang.org/t/upcoming-breakage-starting-in-rust-1-7-from-rfcs-1214-and-136/4207). To reduce the impact to your
downstream users I suggest publishing a new revision containing this
patch prior to the 1.7 release.
