### PR TITLE
Reset on checkin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,14 +263,9 @@ impl<T> PoolInner<T> {
     }
 
     fn checkin(&self, ptr: *mut Entry<T>) {
-        let mut idx;
-        let mut entry: &mut Entry<T>;
-
-        unsafe {
-            // Figure out the index
-            idx = ((ptr as usize) - (self.ptr as usize)) / self.entry_size;
-            entry = mem::transmute(ptr);
-        }
+        // Figure out the index
+        let idx = ((ptr as usize) - (self.ptr as usize)) / self.entry_size;
+        let entry: &mut Entry<T> = unsafe { mem::transmute(ptr) };
 
         debug_assert!(idx < self.count, "invalid index; idx={}", idx);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl<T: Reset> Pool<T> {
                     inner: self.inner.clone(),
                 }
             }).map(|mut checkout| {
-                checkout.reset();
+                checkout.reset_on_checkout();
                 checkout
             })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ use std::{mem, ops, ptr, usize};
 use std::cell::UnsafeCell;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize, Ordering};
-pub use reset::{Reset, Dirty};
+pub use reset::{Reset, Dirty, ResetOnCheckin};
 
 mod reset;
 

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -36,7 +36,7 @@ pub trait Reset {
     fn reset_on_checkin(&mut self);
 }
 
-/// Default catch-all types behaviour for `Reset`: perform reset during checkout only.
+/// Default `Reset` behaviour for types which don't implement it: Reset only during checkout.
 impl <T: Default + Clone> Reset for T {
     fn reset_on_checkout(&mut self) {
         // For most of the stdlib collections, this will "clear" the collection

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -8,6 +8,10 @@ impl <T> Reset for Dirty<T> {
     fn reset_on_checkout(&mut self) {
         // Do nothing!
     }
+
+    fn reset_on_checkin(&mut self) {
+        ();
+    }
 }
 
 unsafe impl <T: Send> Send for Dirty<T> {}
@@ -29,12 +33,18 @@ impl <T> DerefMut for Dirty<T> {
 /// Resetting an object reverts that object back to a default state.
 pub trait Reset {
     fn reset_on_checkout(&mut self);
+    fn reset_on_checkin(&mut self);
 }
 
-// For most of the stdlib collections, this will "clear" the collection
-// without deallocating.
+/// Default catch-all types behaviour for `Reset`: perform reset during checkout only.
 impl <T: Default + Clone> Reset for T {
     fn reset_on_checkout(&mut self) {
+        // For most of the stdlib collections, this will "clear" the collection
+        // without deallocating.
         self.clone_from(&Default::default());
+    }
+
+    fn reset_on_checkin(&mut self) {
+        ();
     }
 }

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut};
 pub struct Dirty<T>(pub T);
 
 impl <T> Reset for Dirty<T> {
-    fn reset(&mut self) {
+    fn reset_on_checkout(&mut self) {
         // Do nothing!
     }
 }
@@ -28,13 +28,13 @@ impl <T> DerefMut for Dirty<T> {
 
 /// Resetting an object reverts that object back to a default state.
 pub trait Reset {
-    fn reset(&mut self);
+    fn reset_on_checkout(&mut self);
 }
 
 // For most of the stdlib collections, this will "clear" the collection
 // without deallocating.
 impl <T: Default + Clone> Reset for T {
-    fn reset(&mut self) {
+    fn reset_on_checkout(&mut self) {
         self.clone_from(&Default::default());
     }
 }

--- a/src/reset.rs
+++ b/src/reset.rs
@@ -2,6 +2,7 @@ use std::default::Default;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug)]
+/// Implements the `Reset` trait which resets nothing.
 pub struct Dirty<T>(pub T);
 
 impl <T> Reset for Dirty<T> {
@@ -26,6 +27,32 @@ impl <T> Deref for Dirty<T> {
 
 impl <T> DerefMut for Dirty<T> {
     fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+pub struct ResetOnCheckin<T: Default + Clone>(pub T);
+
+impl<T: Default + Clone> Reset for ResetOnCheckin<T> {
+    fn reset_on_checkout(&mut self) {
+        ();
+    }
+
+    fn reset_on_checkin(&mut self) {
+        self.clone_from(&Default::default());
+    }
+}
+
+impl<T: Default + Clone> Deref for ResetOnCheckin<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Default + Clone> DerefMut for ResetOnCheckin<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }


### PR DESCRIPTION
On certain usage patterns it might be more suitable to reset the values of the encapsulated data during checkin (When `Checkout::drop()` is executed) instead of during checkout.